### PR TITLE
Fix display of times in result list of past solves

### DIFF
--- a/src/classes/timer.ts
+++ b/src/classes/timer.ts
@@ -176,6 +176,12 @@ export default class Timer {
         return Timer.getTime(Measurements.f2l4Solve, Marks.f2l4Inspection)
     }
 
+    public static getF2lTime(): number {
+        return Timer.getF2l1InspectionTime() + Timer.getF2l1SolveTime() + Timer.getF2l2InspectionTime()
+        + Timer.getF2l2SolveTime() + Timer.getF2l3InspectionTime() + Timer.getF2l3SolveTime()
+        + Timer.getF2l4InspectionTime() + Timer.getF2l4SolveTime()
+    }
+
     public static getOllInspectionTime(): number {
         return Timer.getTime(Measurements.ollInspection, Marks.f2l4Solve)
     }
@@ -184,12 +190,20 @@ export default class Timer {
         return Timer.getTime(Measurements.ollSolve, Marks.ollInspection)
     }
 
+    public static getOllTime(): number {
+        return Timer.getOllInspectionTime() + Timer.getOllSolveTime()
+    }
+
     public static getPllInspectionTime(): number {
         return Timer.getTime(Measurements.pllInspection, Marks.ollSolve)
     }
 
     public static getPllSolveTime(): number {
         return Timer.getTime(Measurements.pllSolve, Marks.pllInspection)
+    }
+
+    public static getPllTime(): number {
+        return Timer.getPllInspectionTime() + Timer.getPllSolveTime()
     }
 
     public static getAUFTime(): number {

--- a/src/components/Results.vue
+++ b/src/components/Results.vue
@@ -64,13 +64,13 @@ export default class Results extends Vue {
         this.results.unshift({
             scramble: this.game.scramble.join(' ') || 'Unknown',
             cross: this.seconds(Timer.getCrossSolveTime()),
-            f2l: this.seconds(Timer.getF2l1SolveTime()),
-            oll: this.seconds(Timer.getOllSolveTime()),
-            pll: this.seconds(Timer.getPllSolveTime()),
+            f2l: this.seconds(Timer.getF2lTime()),
+            oll: this.seconds(Timer.getOllTime()),
+            pll: this.seconds(Timer.getPllTime()),
             auf: this.seconds(Timer.getAUFTime()),
             turns: this.game.turns,
             tps: this.game.tps(),
-            time: this.game.time / 1000
+            time: this.seconds(Timer.getSolveTime())
         })
         localStorage.setItem(this.localStorageKey, JSON.stringify(this.results))
     }


### PR DESCRIPTION
This fixes the times of the different phases of the past solves which is shown at the botton of the window.